### PR TITLE
Safe cast numeric_value

### DIFF
--- a/models/klaviyo__person_campaign_flow.sql
+++ b/models/klaviyo__person_campaign_flow.sql
@@ -18,7 +18,7 @@ pivot_out_events as (
 
     -- sum up the numeric value associated with events (most likely will mean revenue)
     {% for rm in var('klaviyo__sum_revenue_metrics') %}
-    , sum(case when lower(type) = '{{ rm | lower }}' then numeric_value else 0 end) 
+    , sum(case when lower(type) = '{{ rm | lower }}' then {{ dbt_utils.safe_cast('numeric_value', 'numeric') }} else 0 end) 
         as {{ 'sum_revenue_' ~ rm | replace(' ', '_') | replace('(', '') | replace(')', '') | lower }} -- removing special characters that I have seen in different integration events
     {% endfor %}
 


### PR DESCRIPTION
Its possible for the source 'property_value' field to contain strings. This macro drops non-numeric values and casts the numeric values to numeric. 

See [issue 17]( #17 ) for original report